### PR TITLE
Timeout support. >=v1beta3 support. Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Some optional params also exist on initialising the client.
 ```js
 {
     namespace:  'someNamespace', // filter all client requests by a namespace - default is no namespace
-    apiPrefix: 'someNamespace' // for APIs with a different API prefix to 'api'
+    timeout: 20000 // A timeout (in ms) for requests to k8 apis
 }
 ```
 

--- a/lib/collections.js
+++ b/lib/collections.js
@@ -65,6 +65,8 @@ var factory = module.exports = function (request) {
                     id = id.metadata.guid || id.metadata.name;
                 } else if (typeof id.index !== 'undefined') {
                     id = id.index;
+                }else if (typeof id.id !== 'undefined'){
+                  id = id.id;
                 }
             }
 

--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -1,9 +1,9 @@
-var FormData     = require('form-data');
+var FormData = require('form-data'),
+    url = require('url'),
+    util = require('util');
 
 require('sugar');
 
-var url = require('url');
-var util = require('util');
 
  /**
   * kubernetes client.
@@ -49,7 +49,7 @@ var VcapClient = module.exports = function (info) {
     this.namespaces = collections.create('namespaces');
 
     // ~ pods
-    this.pods = collections.create('pods');
+    this.pods = collections.create('pods', null, [{ method: 'log', nested: false }], null);
 
     // ~ services
     this.services = collections.create('services');

--- a/lib/request.js
+++ b/lib/request.js
@@ -27,7 +27,7 @@ module.exports = function (info) {
         }
         
         // v1beta3 and greater moves to lowercase endpoints, no longer camel case. Also intros namespacing in the URL
-        if ((version === 'v1beta3' || version === 'v1') && namespace){
+        if ((version === 'v1beta3' || version === 'v1')){
           object.endpoint = object.endpoint.toLowerCase();
           if (namespace && !object.endpoint.match(/^namespace/)){
             return protocol + '://' + host + '/' + path.join(prefix, version, 'namespaces', namespace, object.endpoint);
@@ -102,7 +102,7 @@ module.exports = function (info) {
                 Authorization: 'bearer ' + token
             };
         }
-        if (namespace){
+        if (namespace && version.match(/v1beta(1|2)/)){
           object.qs = object.qs || {};
           object.qs.namespace = namespace;
         }

--- a/lib/request.js
+++ b/lib/request.js
@@ -14,24 +14,28 @@ var url     = require('url'),
 module.exports = function (info) {
     var protocol = info.protocol || 'https', 
     host = info.host,
-    apiPrefix = info.apiPrefix || 'api',
     version = info.version, 
     token = info.token,
+    timeout = info.timeout,
     namespace = info.namespace;
     
     var getUrl = function (object) {
-        /**
-        return url.format({
-            protocol: protocol,
-            hostname: host,
-            pathname: 'api/v1beta2/' + object.endpoint
-        });
-        **/
-        var prefix = apiPrefix;
+        var prefix = 'api';
+        
         if (object.options && object.options.apiPrefix){
           prefix = object.options.apiPrefix;
         }
+        
+        // v1beta3 and greater moves to lowercase endpoints, no longer camel case. Also intros namespacing in the URL
+        if ((version === 'v1beta3' || version === 'v1') && namespace){
+          object.endpoint = object.endpoint.toLowerCase();
+          if (namespace && !object.endpoint.match(/^namespace/)){
+            return protocol + '://' + host + '/' + path.join(prefix, version, 'namespaces', namespace, object.endpoint);
+          }
+        }
+        
         return protocol + '://' + host + '/' + path.join(prefix, version, object.endpoint);
+        
     };
 
     var getAuthUrl = function (callback) {
@@ -60,6 +64,7 @@ module.exports = function (info) {
         object.url = getUrl(object);
         delete object.endpoint;
         object.json = object.json || true;
+        object.timeout = timeout;
         if (object.json) {
             if ([ 'object', 'boolean' ].none(typeof object.json)) {
                 object.body = object.json;

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "url": "https://github.com/tenxcloud/node-kubernetes-client/issues"
   },
   "dependencies": {
-    "request": "~2.26.0",
-    "sugar": "~1.3.9",
+    "async": "~0.2.9",
     "form-data": "~0.1.0",
-    "json-gate": "~0.8.21",
     "glob": "*",
-    "async": "~0.2.9"
+    "json-gate": "~0.8.21",
+    "request": "~2.26.0",
+    "sugar": "~1.3.9"
   },
   "devDependencies": {
     "jshinthelper": "git+ssh://git@github.com:tenxcloud/jshinthelper.git#0.5.0",


### PR DESCRIPTION
In our last P/R we talked about v1beta3 apis and greater. I've added support for these now (also works with `v1`). Adds support for namespacing in the URL too. 

Adds support for k8 client timeout on requests as needed. 
Removes global apiPrefix option - sorry, turns out I didn't understand this properly. Things which extend k8 apis should only set the apiPrefix when creating the collection, not globally. 
Resolves certain ID items on v1beta1 entities. 
Adds support for logs. 
Reorders package.json alphabetically (npm install --save did this)

Contains contributions from @josmas rebased into a single commit - thanks Jose!
