### PR TITLE
Allow handling of 401 and 403 errors differently by implementing user

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -13,8 +13,8 @@ var InvalidDataError = module.exports.InvalidDataError = function (body) {
 
 util.inherits(InvalidDataError, ClientError);
 
-var AuthorizationError = module.exports.AuthorizationError = function (body) {
-    ClientError.call(this, body, 403);
+var AuthorizationError = module.exports.AuthorizationError = function (body, statusCode) {
+    ClientError.call(this, body, statusCode);
 };
 
 util.inherits(AuthorizationError, ClientError);
@@ -31,7 +31,7 @@ module.exports.get = function (resp) {
         return new InvalidDataError(resp.body);
     case 401:
     case 403:
-        return new AuthorizationError(resp.body);
+        return new AuthorizationError(resp.body, resp.statusCode);
     case 404:
         return new NotFoundError(resp.body);
     default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-kubernetes-client",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Kubernetes client of Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
An issue I've encountered is 401 and 403 both being returned to the end user in an error object as 403. 
(Roughly) 401 means unauthenticated / authentication expired, 403 means no permission to access - fairly different things
