### PR TITLE
Add patch functionality

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -1,0 +1,363 @@
+# Kubernetes API Compatibility Status
+[Kubernetes Swagger Specification](http://kubernetes.io/third_party/swagger-ui/)
+
+This document details the client's known compatibility with version `v1`
+of the Kubernetes API endpoints. It shall be updated continuously as new
+testing information is collected.
+
+Independent testing is appreciated. If tests are performed on any API
+endpoints that have not yet been verified, a pull request should be
+submitted to add the test results to the appropriate table.
+
+#### Legend
+| Status | Description of status key
+|:------:|:---------------------------
+| OK     | Main endpoint and all tested parameters are fully functional
+| PART   | Main endpoint works but some optional parameters do not
+| NONE   | Main endpoint does not work
+| ?      | Unknown, not yet tested
+
+
+## Primary API Endpoints
+
+|           |  Events                         | Status |
+|:---------:|:--------------------------------|:------:|
+| `GET`     | events                          | OK
+| `GET`     | namespaces/{ns}/events          | OK
+| `POST`    | namespaces/{ns}/events          | ?
+| `GET`     | namespaces/{ns}/events/{name}   | OK
+| `PUT`     | namespaces/{ns}/events/{name}   | ?
+| `PATCH`   | namespaces/{ns}/events/{name}   | ?
+| `DELETE`  | namespaces/{ns}/events/{name}   | ?
+
+
+|           |  Endpoints                          | Status |
+|:---------:|:------------------------------------|:------:|
+| `GET`     | endpoints                           | OK
+| `GET`     | namespaces/{ns}/endpoints           | OK
+| `POST`    | namespaces/{ns}/endpoints           | ?
+| `GET`     | namespaces/{ns}/endpoints/{name}    | OK
+| `PUT`     | namespaces/{ns}/endpoints/{name}    | ?
+| `PATCH`   | namespaces/{ns}/endpoints/{name}    | ?
+| `DELETE`  | namespaces/{ns}/endpoints/{name}    | ?
+
+
+|           |  Limit Ranges                       | Status |
+|:---------:|:------------------------------------|:------:|
+| `GET`     | limitranges                         | OK
+| `GET`     | namespaces/{ns}/limitranges         | OK
+| `POST`    | namespaces/{ns}/limitranges         | ?
+| `GET`     | namespaces/{ns}/limitranges/{name}  | OK
+| `PUT`     | namespaces/{ns}/limitranges/{name}  | ?
+| `PATCH`   | namespaces/{ns}/limitranges/{name}  | ?
+| `DELETE`  | namespaces/{ns}/limitranges/{name}  | ?
+
+
+|           |  Namespaces                 | Status |
+|:---------:|:----------------------------|:------:|
+| `GET`     | namespaces                  | OK
+| `POST`    | namespaces                  | OK
+| `GET`     | namespaces/{name}           | OK
+| `PUT`     | namespaces/{name}           | OK
+| `PATCH`   | namespaces/{name}           | OK
+| `DELETE`  | namespaces/{name}           | OK
+| `PUT`     | namespaces/{name}/finalize  | ?
+| `PUT`     | namespaces/{name}/status    | ?
+
+
+|           |  Nodes                | Status |
+|:---------:|:----------------------|:------:|
+| `GET`     | nodes                 | OK
+| `POST`    | nodes                 | ?
+| `GET`     | nodes/{name}          | OK
+| `PUT`     | nodes/{name}          | ?
+| `PATCH`   | nodes/{name}          | OK
+| `DELETE`  | nodes/{name}          | ?
+| `PUT`     | nodes/{name}/status   | ?
+
+
+|           |  Persistent Volume Claims                             | Status |
+|:---------:|:------------------------------------------------------|:------:|
+| `GET`     | persistentvolumeclaims                                | ?
+| `GET`     | namespaces/{ns}/persistentvolumeclaims                | ?
+| `POST`    | namespaces/{ns}/persistentvolumeclaims                | ?
+| `GET`     | namespaces/{ns}/persistentvolumeclaims/{name}         | ?
+| `PUT`     | namespaces/{ns}/persistentvolumeclaims/{name}         | ?
+| `PATCH`   | namespaces/{ns}/persistentvolumeclaims/{name}         | ?
+| `DELETE`  | namespaces/{ns}/persistentvolumeclaims/{name}         | ?
+| `PUT`     | namespaces/{ns}/persistentvolumeclaims/{name}/status  | ?
+
+
+|           |  Persistent Volumes               | Status |
+|:---------:|:----------------------------------|:------:|
+| `GET`     | persistentvolumes                 | ?
+| `POST`    | persistentvolumes                 | ?
+| `GET`     | persistentvolumes/{name}          | ?
+| `PUT`     | persistentvolumes/{name}          | ?
+| `PATCH`   | persistentvolumes/{name}          | ?
+| `DELETE`  | persistentvolumes/{name}          | ?
+| `PUT`     | persistentvolumes/{name}/status   | ?
+
+
+|           |  Pod Templates                        | Status |
+|:---------:|:--------------------------------------|:------:|
+| `GET`     | podtemplates                          | ?
+| `GET`     | namespaces/{ns}/podtemplates          | ?
+| `POST`    | namespaces/{ns}/podtemplates          | ?
+| `GET`     | namespaces/{ns}/podtemplates/{name}   | ?
+| `PUT`     | namespaces/{ns}/podtemplates/{name}   | ?
+| `PATCH`   | namespaces/{ns}/podtemplates/{name}   | ?
+| `DELETE`  | namespaces/{ns}/podtemplates/{name}   | ?
+
+
+|           |  Pods                                         | Status |
+|:---------:|:----------------------------------------------|:------:|
+| `GET`     | pods                                          | OK
+| `GET`     | namespaces/{ns}/pods                          | OK
+| `POST`    | namespaces/{ns}/pods                          | ?
+| `GET`     | namespaces/{ns}/pods/{name}                   | OK
+| `PUT`     | namespaces/{ns}/pods/{name}                   | ?
+| `PATCH`   | namespaces/{ns}/pods/{name}                   | ?
+| `DELETE`  | namespaces/{ns}/pods/{name}                   | ?
+| `GET`     | namespaces/{ns}/pods/{name}/attach            | ?
+| `POST`    | namespaces/{ns}/pods/{name}/attach            | ?
+| `POST`    | namespaces/{ns}/pods/{name}/binding           | ?
+| `GET`     | namespaces/{ns}/pods/{name}/exec              | ?
+| `POST`    | namespaces/{ns}/pods/{name}/exec              | ?
+| `GET`     | namespaces/{ns}/pods/{name}/log               | ?
+| `GET`     | namespaces/{ns}/pods/{name}/portforward       | ?
+| `POST`    | namespaces/{ns}/pods/{name}/portforward       | ?
+| `GET`     | namespaces/{ns}/pods/{name}/proxy             | ?
+| `PUT`     | namespaces/{ns}/pods/{name}/proxy             | ?
+| `POST`    | namespaces/{ns}/pods/{name}/proxy             | ?
+| `DELETE`  | namespaces/{ns}/pods/{name}/proxy             | ?
+| `OPTIONS` | namespaces/{ns}/pods/{name}/proxy             | ?
+| `HEAD`    | namespaces/{ns}/pods/{name}/proxy             | ?
+| `GET`     | namespaces/{ns}/pods/{name}/proxy/{path:*}    | ?
+| `PUT`     | namespaces/{ns}/pods/{name}/proxy/{path:*}    | ?
+| `POST`    | namespaces/{ns}/pods/{name}/proxy/{path:*}    | ?
+| `DELETE`  | namespaces/{ns}/pods/{name}/proxy/{path:*}    | ?
+| `OPTIONS` | namespaces/{ns}/pods/{name}/proxy/{path:*}    | ?
+| `HEAD`    | namespaces/{ns}/pods/{name}/proxy/{path:*}    | ?
+| `PUT`     | namespaces/{ns}/pods/{name}/status            | ?
+
+
+|           |  Replication Controllers                              | Status |
+|:---------:|:------------------------------------------------------|:------:|
+| `GET`     | replicationcontrollers                                | OK
+| `GET`     | namespaces/{ns}/replicationcontrollers                | OK
+| `POST`    | namespaces/{ns}/replicationcontrollers                | ?
+| `GET`     | namespaces/{ns}/replicationcontrollers/{name}         | ?
+| `PUT`     | namespaces/{ns}/replicationcontrollers/{name}         | ?
+| `PATCH`   | namespaces/{ns}/replicationcontrollers/{name}         | ?
+| `DELETE`  | namespaces/{ns}/replicationcontrollers/{name}         | ?
+| `PUT`     | namespaces/{ns}/replicationcontrollers/{name}/status  | ?
+
+
+|           |  Resource Quotas                              | Status |
+|:---------:|:----------------------------------------------|:------:|
+| `GET`     | resourcequotas                                | ?
+| `GET`     | namespaces/{ns}/resourcequotas                | ?
+| `POST`    | namespaces/{ns}/resourcequotas                | ?
+| `GET`     | namespaces/{ns}/resourcequotas/{name}         | ?
+| `PUT`     | namespaces/{ns}/resourcequotas/{name}         | ?
+| `PATCH`   | namespaces/{ns}/resourcequotas/{name}         | ?
+| `DELETE`  | namespaces/{ns}/resourcequotas/{name}         | ?
+| `PUT`     | namespaces/{ns}/resourcequotas/{name}/status  | ?
+
+
+|           |  Secrets                          | Status |
+|:---------:|:----------------------------------|:------:|
+| `GET`     | secrets                           | ?
+| `GET`     | namespaces/{ns}/secrets           | ?
+| `POST`    | namespaces/{ns}/secrets           | ?
+| `GET`     | namespaces/{ns}/secrets/{name}    | ?
+| `PUT`     | namespaces/{ns}/secrets/{name}    | ?
+| `PATCH`   | namespaces/{ns}/secrets/{name}    | ?
+| `DELETE`  | namespaces/{ns}/secrets/{name}    | ?
+
+
+|           |  Service Accounts                         | Status |
+|:---------:|:------------------------------------------|:------:|
+| `GET`     | serviceaccounts                           | ?
+| `GET`     | namespaces/{ns}/serviceaccounts           | ?
+| `POST`    | namespaces/{ns}/serviceaccounts           | ?
+| `GET`     | namespaces/{ns}/serviceaccounts/{name}    | ?
+| `PUT`     | namespaces/{ns}/serviceaccounts/{name}    | ?
+| `PATCH`   | namespaces/{ns}/serviceaccounts/{name}    | ?
+| `DELETE`  | namespaces/{ns}/serviceaccounts/{name}    | ?
+
+
+|           |  Services                         | Status |
+|:---------:|:----------------------------------|:------:|
+| `GET`     | services                          | OK
+| `GET`     | namespaces/{ns}/services          | OK
+| `POST`    | namespaces/{ns}/services          | ?
+| `GET`     | namespaces/{ns}/services/{name}   | OK
+| `PUT`     | namespaces/{ns}/services/{name}   | ?
+| `PATCH`   | namespaces/{ns}/services/{name}   | ?
+| `DELETE`  | namespaces/{ns}/services/{name}   | ?
+
+
+------------------------------------------------------------------------
+
+
+## Proxy API Endpoints
+
+|           |  Proxy Nodes                  | Status |
+|:---------:|:------------------------------|:------:|
+| `GET`     | proxy/nodes/{name}            | ?
+| `PUT`     | proxy/nodes/{name}            | ?
+| `POST`    | proxy/nodes/{name}            | ?
+| `DELETE`  | proxy/nodes/{name}            | ?
+| `OPTIONS` | proxy/nodes/{name}            | ?
+| `HEAD`    | proxy/nodes/{name}            | ?
+| `GET`     | proxy/nodes/{name}/{path:*}   | ?
+| `PUT`     | proxy/nodes/{name}/{path:*}   | ?
+| `POST`    | proxy/nodes/{name}/{path:*}   | ?
+| `DELETE`  | proxy/nodes/{name}/{path:*}   | ?
+| `OPTIONS` | proxy/nodes/{name}/{path:*}   | ?
+| `HEAD`    | proxy/nodes/{name}/{path:*}   | ?
+
+
+|           |  Proxy Pods                                   | Status |
+|:---------:|:----------------------------------------------|:------:|
+| `GET`     | proxy/namespaces/{ns}/pods/{name}             | ?
+| `PUT`     | proxy/namespaces/{ns}/pods/{name}             | ?
+| `POST`    | proxy/namespaces/{ns}/pods/{name}             | ?
+| `DELETE`  | proxy/namespaces/{ns}/pods/{name}             | ?
+| `OPTIONS` | proxy/namespaces/{ns}/pods/{name}             | ?
+| `HEAD`    | proxy/namespaces/{ns}/pods/{name}             | ?
+| `GET`     | proxy/namespaces/{ns}/pods/{name}/{path:*}    | ?
+| `PUT`     | proxy/namespaces/{ns}/pods/{name}/{path:*}    | ?
+| `POST`    | proxy/namespaces/{ns}/pods/{name}/{path:*}    | ?
+| `DELETE`  | proxy/namespaces/{ns}/pods/{name}/{path:*}    | ?
+| `OPTIONS` | proxy/namespaces/{ns}/pods/{name}/{path:*}    | ?
+| `HEAD`    | proxy/namespaces/{ns}/pods/{name}/{path:*}    | ?
+
+
+|           |  Proxy Services                                   | Status |
+|:---------:|:--------------------------------------------------|:------:|
+| `GET`     | proxy/namespaces/{ns}/services/{name}             | ?
+| `PUT`     | proxy/namespaces/{ns}/services/{name}             | ?
+| `POST`    | proxy/namespaces/{ns}/services/{name}             | ?
+| `DELETE`  | proxy/namespaces/{ns}/services/{name}             | ?
+| `OPTIONS` | proxy/namespaces/{ns}/services/{name}             | ?
+| `HEAD`    | proxy/namespaces/{ns}/services/{name}             | ?
+| `GET`     | proxy/namespaces/{ns}/services/{name}/{path:*}    | ?
+| `PUT`     | proxy/namespaces/{ns}/services/{name}/{path:*}    | ?
+| `POST`    | proxy/namespaces/{ns}/services/{name}/{path:*}    | ?
+| `DELETE`  | proxy/namespaces/{ns}/services/{name}/{path:*}    | ?
+| `OPTIONS` | proxy/namespaces/{ns}/services/{name}/{path:*}    | ?
+| `HEAD`    | proxy/namespaces/{ns}/services/{name}/{path:*}    | ?
+
+
+------------------------------------------------------------------------
+
+
+#### Watch API Endpoints
+
+|           |  Watch Endpoints                          | Status |
+|:---------:|:------------------------------------------|:------:|
+| `GET`     | watch/endpoints                           | ?
+| `GET`     | watch/namespaces/{ns}/endpoints           | ?
+| `GET`     | watch/namespaces/{ns}/endpoints/{name}    | ?
+
+
+|           |  Watch Events                         | Status |
+|:---------:|:--------------------------------------|:------:|
+| `GET`     | watch/events                          | ?
+| `GET`     | watch/namespaces/{ns}/events          | ?
+| `GET`     | watch/namespaces/{ns}/events/{name}   | ?
+
+
+|           |  Watch Limit Ranges                       | Status |
+|:---------:|:------------------------------------------|:------:|
+| `GET`     | watch/limitranges                         | ?
+| `GET`     | watch/namespaces/{ns}/limitranges         | ?
+| `GET`     | watch/namespaces/{ns}/limitranges/{name}  | ?
+
+
+|           |  Watch Namespaces         | Status |
+|:---------:|:--------------------------|:------:|
+| `GET`     | watch/namespaces          | ?
+| `GET`     | watch/namespaces/{name}   | ?
+
+
+|           |  Watch Nodes             | Status |
+|:---------:|:----------------------|:------:|
+| `GET`     | watch/nodes           | ?
+| `GET`     | watch/nodes/{name}    | ?
+
+
+|           |  Watch Persistent Volume Claims                       | Status |
+|:---------:|:------------------------------------------------------|:------:|
+| `GET`     | watch/persistentvolumeclaims                          | ?
+| `GET`     | watch/namespaces/{ns}/persistentvolumeclaims          | ?
+| `GET`     | watch/namespaces/{ns}/persistentvolumeclaims/{name}   | ?
+
+
+|           |  Watch Persistent Volumes         | Status |
+|:---------:|:----------------------------------|:------:|
+| `GET`     | watch/persistentvolumes           | ?
+| `GET`     | watch/persistentvolumes/{name}    | ?
+
+
+|           |  Watch Pod Templates                      | Status |
+|:---------:|:------------------------------------------|:------:|
+| `GET`     | watch/podtemplates                        | ?
+| `GET`     | watch/namespaces/{ns}/podtemplates        | ?
+| `GET`     | watch/namespaces/{ns}/podtemplates/{name} | ?
+
+
+|           |  Watch Pods                       | Status |
+|:---------:|:----------------------------------|:------:|
+| `GET`     | watch/pods                        | ?
+| `GET`     | watch/namespaces/{ns}/pods        | ?
+| `GET`     | watch/namespaces/{ns}/pods/{name} | ?
+
+
+|           |  Watch Replication Controllers                        | Status |
+|:---------:|:------------------------------------------------------|:------:|
+| `GET`     | watch/replicationcontrollers                          | ?
+| `GET`     | watch/namespaces/{ns}/replicationcontrollers          | ?
+| `GET`     | watch/namespaces/{ns}/replicationcontrollers/{name}   | ?
+
+
+|           |  Watch Resource Quotas                        | Status |
+|:---------:|:----------------------------------------------|:------:|
+| `GET`     | watch/resourcequotas                          | ?
+| `GET`     | watch/namespaces/{ns}/resourcequotas          | ?
+| `GET`     | watch/namespaces/{ns}/resourcequotas/{name}   | ?
+
+
+|           |  Watch Secrets                        | Status |
+|:---------:|:--------------------------------------|:------:|
+| `GET`     | watch/secrets                         | ?
+| `GET`     | watch/namespaces/{ns}/secrets         | ?
+| `GET`     | watch/namespaces/{ns}/secrets/{name}  | ?
+
+
+|           |  Watch Service Accounts                       | Status |
+|:---------:|:----------------------------------------------|:------:|
+| `GET`     | watch/serviceaccounts                         | ?
+| `GET`     | watch/namespaces/{ns}/serviceaccounts         | ?
+| `GET`     | watch/namespaces/{ns}/serviceaccounts/{name}  | ?
+
+
+|           |  Watch Services                       | Status |
+|:---------:|:--------------------------------------|:------:|
+| `GET`     | watch/services                        | ?
+| `GET`     | watch/namespaces/{ns}/services        | ?
+| `GET`     | watch/namespaces/{ns}/services/{name} | ?
+
+
+------------------------------------------------------------------------
+
+
+|           |  Miscellaneous Endpoints                  | Status |
+|:---------:|:------------------------------------------|:------:|
+| `GET`     | /api/v1                                   | ?
+| `POST`    | namespaces/{ns}/bindings                  | ?
+| `GET`     | componentstatuses                         | ?
+| `GET`     | componentstatuses/{name}                  | ?

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+Copyright 2016 Cisco Systems, Inc.
+https://github.com/ryclarke/node-kubernetes-client
+
 Copyright 2015 Tenxcloud.com
 https://github.com/tenxcloud/node-kubernetes-client
 

--- a/lib/collections.js
+++ b/lib/collections.js
@@ -43,6 +43,17 @@ var factory = module.exports = function (request) {
             });
         };
 
+        //added by Ryan Clarke (ryclarke@cisco.com)
+        this.patch = function (innerId, callback) {
+            request({
+                endpoint: getPath(parentCollection, id, collection, innerId),
+                method: 'PATCH',
+                options: options
+            }, function (err, result) {
+                callback(err, result && (result.resources || result));
+            });
+        };
+
         this.delete = function (innerId, callback) {
             request({
                 endpoint: getPath(parentCollection, id, collection, innerId),
@@ -251,6 +262,16 @@ var factory = module.exports = function (request) {
             request({
                 endpoint: getPath(collection, id),
                 method: 'PUT',
+                json: body,
+                options : options
+            }, callback);
+        };
+
+        //added by Ryan Clarke (ryclarke@cisco.com)
+        this.patch = function (id, body, callback) {
+            request({
+                endpoint: getPath(collection, id),
+                method: 'PATCH',
                 json: body,
                 options : options
             }, callback);

--- a/lib/collections.js
+++ b/lib/collections.js
@@ -1,7 +1,7 @@
-var errors = require('./errors');
-var createSchema = require('json-gate').createSchema;
-var async = require('async');
-var util = require('util');
+var errors = require('./errors')
+  , createSchema = require('json-gate').createSchema
+  , async = require('async')
+  , util = require('util');
 
 require('sugar');
 
@@ -15,9 +15,9 @@ var factory = module.exports = function (request) {
     var InnerCollection = function (parentCollection, id, collection, options) {
         this.get = function (callback) {
             request({
-                endpoint: getPath(parentCollection, id, collection),
-                method: 'GET',
-                options : options
+                endpoint: getPath(parentCollection, id, collection)
+                , method: 'GET'
+                , options : options
             }, function (err, result) {
                 callback(err, result && (result.resources || result));
             });
@@ -25,9 +25,9 @@ var factory = module.exports = function (request) {
 
         this.post = function (innerId, callback) {
             request({
-                endpoint: getPath(parentCollection, id, collection, innerId),
-                method: 'POST',
-                options : options
+                endpoint: getPath(parentCollection, id, collection, innerId)
+                , method: 'POST'
+                , options : options
             }, function (err, result) {
                 callback(err, result && (result.resources || result));
             });
@@ -35,9 +35,9 @@ var factory = module.exports = function (request) {
 
         this.put = function (innerId, callback) {
             request({
-                endpoint: getPath(parentCollection, id, collection, innerId),
-                method: 'PUT',
-                options : options
+                endpoint: getPath(parentCollection, id, collection, innerId)
+                , method: 'PUT'
+                , options : options
             }, function (err, result) {
                 callback(err, result && (result.resources || result));
             });
@@ -46,9 +46,9 @@ var factory = module.exports = function (request) {
         //added by Ryan Clarke (ryclarke@cisco.com)
         this.patch = function (innerId, callback) {
             request({
-                endpoint: getPath(parentCollection, id, collection, innerId),
-                method: 'PATCH',
-                options: options
+                endpoint: getPath(parentCollection, id, collection, innerId)
+                , method: 'PATCH'
+                , options: options
             }, function (err, result) {
                 callback(err, result && (result.resources || result));
             });
@@ -56,9 +56,9 @@ var factory = module.exports = function (request) {
 
         this.delete = function (innerId, callback) {
             request({
-                endpoint: getPath(parentCollection, id, collection, innerId),
-                method: 'DELETE',
-                options : options
+                endpoint: getPath(parentCollection, id, collection, innerId)
+                , method: 'DELETE'
+                , options : options
             }, function (err, result) {
                 callback(err, result && (result.resources || result));
             });
@@ -76,15 +76,15 @@ var factory = module.exports = function (request) {
                     id = id.metadata.guid || id.metadata.name;
                 } else if (typeof id.index !== 'undefined') {
                     id = id.index;
-                }else if (typeof id.id !== 'undefined'){
-                  id = id.id;
+                }else if (typeof id.id !== 'undefined') {
+                    id = id.id;
                 }
             }
 
             (innerCollections || []).each(function (each) {
-                var method,
-                    innerCollectionName,
-                    isNestedCollection = false;
+                var method
+                  , innerCollectionName
+                  , isNestedCollection = false;
                     options = options || {};
 
                 if (typeof each === 'object') {
@@ -145,15 +145,14 @@ var factory = module.exports = function (request) {
                 multiResults = true;
             }
 
-            var finished = false,
-                results  = [];
+            var finished = false
+              , results  = [];
 
             var requestObject = {
-                endpoint: getPath(collection, query),
-                page:     multiResults ? 1 : null, // don't page if we're
-                                                   // looking up one item
-                method:   'GET',
-                options : options
+                endpoint: getPath(collection, query)
+                , page:     multiResults ? 1 : null // don't page if we're
+                , method:   'GET'                   // looking up one item
+                , options : options
             };
 
             if (query && typeof query === 'object') {
@@ -231,14 +230,14 @@ var factory = module.exports = function (request) {
                endpoint = collection + '/' + query.name + '?namespace=' + query.namespace;
             }
             request({
-                endpoint: endpoint,
-                method: 'GET',
-                options : options
+                endpoint: endpoint
+                , method: 'GET'
+                , options : options
             }, callback);
         };
 
         this.getByName = function (name, callback) {
-            this.get({ name: name }, callback);
+            this.get({name: name}, callback);
         };
 
         this.create = function (body, callback) {
@@ -251,29 +250,29 @@ var factory = module.exports = function (request) {
             }
 
             request({
-                endpoint: getPath(collection),
-                method: 'POST',
-                json: body,
-                options : options
+                endpoint: getPath(collection)
+                , method: 'POST'
+                , json: body
+                , options : options
             }, callback);
         };
 
         this.update = function (id, body, callback) {
             request({
-                endpoint: getPath(collection, id),
-                method: 'PUT',
-                json: body,
-                options : options
+                endpoint: getPath(collection, id)
+                , method: 'PUT'
+                , json: body
+                , options : options
             }, callback);
         };
 
         //added by Ryan Clarke (ryclarke@cisco.com)
         this.patch = function (id, body, callback) {
             request({
-                endpoint: getPath(collection, id),
-                method: 'PATCH',
-                json: body,
-                options : options
+                endpoint: getPath(collection, id)
+                , method: 'PATCH'
+                , json: body
+                , options : options
             }, callback);
         };
 
@@ -284,13 +283,13 @@ var factory = module.exports = function (request) {
             }
 
             var object = {
-                endpoint: getPath(collection, id),
-                method: 'DELETE',
-                options : options
+                endpoint: getPath(collection, id)
+                , method: 'DELETE'
+                , options : options
             };
 
             if (recursive) {
-                object.qs = { recursive: true };
+                object.qs = {recursive: true};
             }
 
             request(object, callback);

--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -1,9 +1,8 @@
-var FormData = require('form-data'),
-    url = require('url'),
-    util = require('util');
+var FormData = require('form-data')
+  , url = require('url')
+  , util = require('util');
 
 require('sugar');
-
 
  /**
   * kubernetes client.

--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -76,7 +76,7 @@ var VcapClient = module.exports = function (info) {
 
     // ~ watch pods
     this.watchPods = collections.create('watch/pods');
-    
+
     // Allow users to create custom collections also
     this.createCollection = collections.create;
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,48 +1,47 @@
-// add header strictSSL: false
-// modified by huangqg
-
-var errors  = require('./errors');
-
-var request = require('request');
+var errors  = require('./errors')
+  , path = require('path')
+  , request = require('request')
+  , url = require('url')
+  , util = require('util');
 
 require('sugar');
 
-var url     = require('url'),
-    util    = require('util'),
-    path    = require('path');
-
 module.exports = function (info) {
-    var protocol = info.protocol || 'https', 
-    host = info.host,
-    version = info.version, 
-    token = info.token,
-    timeout = info.timeout,
-    namespace = info.namespace;
+    var protocol = info.protocol || 'https'
+      , host = info.host
+      , version = info.version 
+      , token = info.token
+      , timeout = info.timeout
+      , namespace = info.namespace;
     
     var getUrl = function (object) {
         var prefix = 'api';
         
-        if (object.options && object.options.apiPrefix){
-          prefix = object.options.apiPrefix;
+        // Allow options to override default  API prefix.
+        if (object.options && object.options.apiPrefix) {
+            prefix = object.options.apiPrefix;
         }
         
-        // v1beta3 and greater moves to lowercase endpoints, no longer camel case. Also intros namespacing in the URL
-        if ((version === 'v1beta3' || version === 'v1')){
-          object.endpoint = object.endpoint.toLowerCase();
-          if (namespace && !object.endpoint.match(/^namespace/)){
-            return protocol + '://' + host + '/' + path.join(prefix, version, 'namespaces', namespace, object.endpoint);
-          }
+        // Define base URL for the query.
+        var query = protocol + '://' + path.join(host, prefix, version);
+        
+        // v1beta3 and greater uses lowercase endpoints instead of
+        //  camelCase and defines namespaces in the query URL.
+        if ((version === 'v1beta3' || version === 'v1')) {
+            endpoint = endpoint.toLowerCase();
+            // Never use URL namespacing for namespace or node endpoints.
+            if (namespace && !endpoint.match(/^namespaces/) && !endpoint.match(/^nodes/)){
+                return query + '/' + path.join('namespaces', namespace, endpoint);
+            }
         }
-        
-        return protocol + '://' + host + '/' + path.join(prefix, version, object.endpoint);
-        
+        return query + '/' + endpoint;
     };
 
     var getAuthUrl = function (callback) {
         request({
-            url: getUrl({ endpoint: 'info' }),
-            json: true,
-            strictSSL: false
+            url: getUrl({endpoint: 'info'})
+            , json: true
+            , strictSSL: false
         }, function (err, resp, body) {
             if (err) {
                 return callback(err);
@@ -60,27 +59,27 @@ module.exports = function (info) {
     };
 
     var makeRequest = function (object, callback) {
-        object = Object.clone(object);
+        var object = Object.clone(object);
         object.url = getUrl(object);
         delete object.endpoint;
-        object.json = object.json || true;
+        if (!object.json) {
+            object.json = true;
+        }
         object.timeout = timeout;
         if (object.json) {
-            if ([ 'object', 'boolean' ].none(typeof object.json)) {
+            if (['object', 'boolean'].none(typeof object.json)) {
                 object.body = object.json;
                 object.json = undefined;
             }
         }
+        // Define paging options.
         if (object.page) {
-            if (! object.qs) {
+            if (!object.qs) {
                 object.qs = {};
             }
-
             object.qs.page = object.page;
             delete object.page;
         }
-        //@important! add by huangqg
-        //skip-ssl
         object.strictSSL = false;
         
         return request(object, function (err, resp, body) {
@@ -97,20 +96,23 @@ module.exports = function (info) {
     };
 
     return function (object, callback) {
-        //set bearer token auth
-        //refactored by Ryan Clarke (ryclarke@cisco.com)
+        // Set request authorization token if it is defined.
         if (token) {
             object.auth = {bearer: token};
         }
-        //set content-type header for patch operations
-        //added by Ryan Clarke (ryclarke@cisco.com)
+        // Fix Content-Type header for PATCH methods.
         if (object.method === 'PATCH') {
-            object.headers = object.headers || {};
+            if (!object.headers) {
+                object.headers = {};
+            }
             object.headers['Content-Type'] = 'application/strategic-merge-patch+json';
         }
-        if (namespace && version.match(/v1beta(1|2)/)){
-          object.qs = object.qs || {};
-          object.qs.namespace = namespace;
+        // Use namespace querystring for older versions of kubernetes.
+        if (namespace && version.match(/v1beta(1|2)/)) {
+            if (!object.qs) {
+                object.qs = {};
+            }
+            object.qs.namespace = namespace;
         }
         return makeRequest(object, callback);
     };

--- a/lib/request.js
+++ b/lib/request.js
@@ -97,10 +97,10 @@ module.exports = function (info) {
     };
 
     return function (object, callback) {
+        //set bearer token auth
+        //refactored by Ryan Clarke (ryclarke@cisco.com)
         if (token) {
-            object.headers = {
-                Authorization: 'bearer ' + token
-            };
+            object.auth = {bearer: token};
         }
         //set content-type header for patch operations
         //added by Ryan Clarke (ryclarke@cisco.com)

--- a/lib/request.js
+++ b/lib/request.js
@@ -26,7 +26,7 @@ module.exports = function (info) {
         var query = protocol + '://' + path.join(host, prefix, version);
 
         // Fix query URL handling for proxy and watch endpoints.
-        if (object.endpoint.match(/^proxy/) {
+        if (object.endpoint.match(/^proxy/)) {
             query = query + '/proxy';
             var endpoint = obejct.endpoint.replace('proxy/', '');
         } else if (object.endpoint.match(/^watch/)) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -102,6 +102,12 @@ module.exports = function (info) {
                 Authorization: 'bearer ' + token
             };
         }
+        //set content-type header for patch operations
+        //added by Ryan Clarke (ryclarke@cisco.com)
+        if (object.method === 'PATCH') {
+            object.headers = object.headers || {};
+            object.headers['Content-Type'] = 'application/strategic-merge-patch+json';
+        }
         if (namespace && version.match(/v1beta(1|2)/)){
           object.qs = object.qs || {};
           object.qs.namespace = namespace;

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,22 +9,33 @@ require('sugar');
 module.exports = function (info) {
     var protocol = info.protocol || 'https'
       , host = info.host
-      , version = info.version 
+      , version = info.version
       , token = info.token
       , timeout = info.timeout
       , namespace = info.namespace;
-    
+
     var getUrl = function (object) {
         var prefix = 'api';
-        
+
         // Allow options to override default  API prefix.
         if (object.options && object.options.apiPrefix) {
             prefix = object.options.apiPrefix;
         }
-        
+
         // Define base URL for the query.
         var query = protocol + '://' + path.join(host, prefix, version);
-        
+
+        // Fix query URL handling for proxy and watch endpoints.
+        if (object.endpoint.match(/^proxy/) {
+            query = query + '/proxy';
+            var endpoint = obejct.endpoint.replace('proxy/', '');
+        } else if (object.endpoint.match(/^watch/)) {
+            query = query + '/watch';
+            var endpoint = object.endpoint.replace('watch/', '');
+        } else {
+            var endpoint = object.endpoint;
+        }
+
         // v1beta3 and greater uses lowercase endpoints instead of
         //  camelCase and defines namespaces in the query URL.
         if ((version === 'v1beta3' || version === 'v1')) {
@@ -81,7 +92,7 @@ module.exports = function (info) {
             delete object.page;
         }
         object.strictSSL = false;
-        
+
         return request(object, function (err, resp, body) {
             if (err) {
                 return callback(err);


### PR DESCRIPTION
I have added patch methods to the Collection so that partial updates can be performed.

**Features:**
.patch() operations are now supported on all collection objects. The syntax for this method is identical to the existing .update() method.

**Compatibility:**
Methods with a type other than PATCH (i.e. everything that I have not just added) should be completely unaffected by this change.

I have also done a minor refactoring of the bearer token handling, to allow the request module to set it automatically rather than manually adding the header ourselves. No errors are expected from this, and none were found in testing, but it can be easily reverted if problems arise from it.
