### PR TITLE
README: remove extra colon in protocol in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var Client = require('node-kubernetes-client');
 
 var client = new Client({
     host:  'xx.xx.xx.xx',
-    protocol: 'https:',
+    protocol: 'https',
     version: 'v1beta2',
     token: 'XYZ'
 });


### PR DESCRIPTION
Didn't work for me with the colon at the end of `https`.
