### PR TITLE
Remove jshinthelper from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "sugar": "~1.3.9"
   },
   "devDependencies": {
-    "jshinthelper": "git+ssh://git@github.com:tenxcloud/jshinthelper.git#0.5.0",
     "mocha": "~1.12.0",
     "should": "2.1.1",
     "mockery": "~1.4.0"


### PR DESCRIPTION
jshinthelper appears unused and tenxcloud/jshinthelper is missing.
