### PR TITLE
Change "license" in package.json from BSD to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docker"
   ],
   "author": "huangqg",
-  "license": "BSD",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/tenxcloud/node-kubernetes-client/issues"
   },


### PR DESCRIPTION
LICENSE is the MIT license, so updating package.json to match.  This also silences the "should be a valid SPDX license expression" npm WARN.
