### PR TITLE
add support to override request object options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .npmignore
 node_modules/
 test/results/
+test/config.json
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Some optional params also exist on initialising the client.
 {
     namespace:  'someNamespace', // filter all client requests by a namespace - default is no namespace
     timeout: 20000 // A timeout (in ms) for requests to k8 apis
+    reqOptions: {} // array of options used to override the npm request module for this client proxy, auth, etc.
 }
 ```
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -12,6 +12,7 @@ module.exports = function (info) {
       , version = info.version
       , token = info.token
       , timeout = info.timeout
+      , reqOptions = info.reqOptions
       , namespace = info.namespace;
 
     var getUrl = function (object) {
@@ -110,6 +111,10 @@ module.exports = function (info) {
         // Set request authorization token if it is defined.
         if (token) {
             object.auth = {bearer: token};
+        }
+        // ovverride options for this request if reqOptions exists
+        if (reqOptions) {
+            Object.assign(object, reqOptions);
         }
         // Fix Content-Type header for PATCH methods.
         if (object.method === 'PATCH') {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "sugar": "~1.3.9"
   },
   "devDependencies": {
-    "jshinthelper": "git+ssh://git@github.com:tenxcloud/jshinthelper.git#0.5.0",
     "mocha": "~1.12.0",
     "should": "2.1.1",
     "mockery": "~1.4.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "form-data": "~0.1.0",
     "glob": "*",
     "json-gate": "~0.8.21",
-    "request": "~2.26.0",
+    "request": "~2.72.0",
     "sugar": "~1.3.9"
   },
   "devDependencies": {

--- a/test/config.json
+++ b/test/config.json
@@ -4,6 +4,9 @@
     "host": "<ip>:<port>",
     "version": "v1beta1",
     "token": "<token>"
+    //, "namespace": "default",
+    //, "timeout": 20000
+    //, "reqOptions": {"proxy": "http://x.x.x.x:xxxx/"}
   },
   "pattern" : "test-*.js",
   "skip" : []

--- a/test/config.json
+++ b/test/config.json
@@ -3,10 +3,8 @@
     "protocol": "https",
     "host": "<ip>:<port>",
     "version": "v1beta1",
-    "token": "<token>"
-    //, "namespace": "default",
-    //, "timeout": 20000
-    //, "reqOptions": {"proxy": "http://x.x.x.x:xxxx/"}
+    "token": "<token>",
+    "reqOptions": {}
   },
   "pattern" : "test-*.js",
   "skip" : []

--- a/test/test-pods.js
+++ b/test/test-pods.js
@@ -19,7 +19,7 @@ describe('Test k8s pods API', function() {
   });
 
   it('should return the pods list', function(done) {
-    client.pods.getBy({"namespace": config.namespace}, function (err, podsArr) {
+    client.pods.getBy({"namespace": config.namespace || "default"}, function (err, podsArr) {
       if (!err) {
         console.log('pods: ' + JSON.stringify(podsArr));
         pods = podsArr.items;

--- a/test/test-pods.js
+++ b/test/test-pods.js
@@ -7,18 +7,19 @@
 var should = require('should');
 var assert = require('assert');
 var fs = require('fs');
-var Client = require('../../../kubernetes/api');
+var Client = require('../');
+var config = require('./config.json');
 
 describe('Test k8s pods API', function() {
   this.timeout(20000);
   var client;
   var pods, podId;
   beforeEach(function() {
-    client = new Client(require('./config.json').k8s);
+    client = new Client(config.k8s);
   });
 
   it('should return the pods list', function(done) {
-    client.pods.getBy({"namespace": "default"}, function (err, podsArr) {
+    client.pods.getBy({"namespace": config.namespace}, function (err, podsArr) {
       if (!err) {
         console.log('pods: ' + JSON.stringify(podsArr));
         pods = podsArr.items;


### PR DESCRIPTION
I need to be able to specify proxy server options on a case by case basis to multiple k8s clusters. I figured this change would allow a whole bunch of different situations like this to be handled. I also need to bump the version of request to fix an issue w/ auth not working when proxy is specified and updated the test-pods.js to respect the namespace parameter if provided.

Lastly, why is Client set to require('../../../kubernetes/api') instead of ../ in the tests? I only updated the one and can roll this back if required or change all of them. I just think other might hit the same issue I hit w/ tests failing.
