### PR TITLE
Remove some broken code from `collection.get`

### DIFF
--- a/lib/collections.js
+++ b/lib/collections.js
@@ -157,13 +157,6 @@ var factory = module.exports = function (request) {
 
             if (query && typeof query === 'object') {
                 requestObject.endpoint = getPath(collection);
-
-                var qs = [];
-                Object.keys(query, function (key, value) {
-                    qs.push(key + ':' + value);
-                });
-
-                requestObject.qs = { q: qs.join(';') };
             }
 
             async.until(function () {


### PR DESCRIPTION
This section of code seems broken for a couple of reasons:
1. `Objects.keys` doesn't appear to take a second parameter.
2. The format of the resulting `requestObject.qs` property looks like it
   might be a little off: it looks like the intention here was maybe
   something more like `requestObject.qs = query`;

If these assertions are correct, then I think `requestObject.qs` will
always be `{ q: '' }` at the end of this code block. This doesn't seem
very useful, hence this proposed change to remove it.
