### PR TITLE
Pass in deletion options when recurse is true

### DIFF
--- a/lib/collections.js
+++ b/lib/collections.js
@@ -282,6 +282,7 @@ var factory = module.exports = function (request) {
             };
 
             if (recursive) {
+                object.json = {"kind":"DeleteOptions", "apiVersion":"v1", "propagationPolicy":"Foreground"};
                 object.qs = {recursive: true};
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-kubernetes-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Kubernetes client of Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a simple change to the Delete API to pass in the DeletionOptions for Kubernetes [GarbageCollection](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/) when recurse is true.